### PR TITLE
Add dedicated API TCP port

### DIFF
--- a/Trabalho_Chat_TCP/API_Chat_TCP/src/main/java/Redes1/API_Chat_TCP/Controller.java
+++ b/Trabalho_Chat_TCP/API_Chat_TCP/src/main/java/Redes1/API_Chat_TCP/Controller.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class Controller {
 
     private static final String HOST = "127.0.0.1";
-    private static final int PORTA_SERVIDOR = 1998;
+    private static final int PORTA_SERVIDOR = 2998;
     private static final String APELIDO_API = "API_Chat_TCP";
 
     @GetMapping("/usuarios/listar")
@@ -70,10 +70,10 @@ public class Controller {
     @PostMapping("/enviar")
     public ResponseEntity<String> enviarMensagemBroadcast(@RequestBody ChatDTO dto) {
         String apelido = "API_Chat_TCP";
-        int portaPrivada = 1998; // Valor arbitrário fixo
+        int portaPrivada = PORTA_SERVIDOR; // Valor arbitrário fixo
         String dadosConexao = apelido + ";" + portaPrivada;
 
-        try (Socket socket = new Socket("127.0.0.1", 1998)) {
+        try (Socket socket = new Socket(HOST, PORTA_SERVIDOR)) {
             OutputStream out = socket.getOutputStream();
 
             // 1. Enviar conexão inicial
@@ -96,10 +96,10 @@ public class Controller {
     @GetMapping("/enviar")
     public ResponseEntity<String> enviarMensagemBroadcastViaUrl(@RequestParam String mensagem) {
         String apelido = "API_Chat_TCP";
-        int portaPrivada = 1998; // Valor arbitrário fixo
+        int portaPrivada = PORTA_SERVIDOR; // Valor arbitrário fixo
         String dadosConexao = apelido + ";" + portaPrivada;
 
-        try (Socket socket = new Socket("127.0.0.1", 1998)) {
+        try (Socket socket = new Socket(HOST, PORTA_SERVIDOR)) {
             OutputStream out = socket.getOutputStream();
 
             // 1. Enviar conexão inicial
@@ -123,10 +123,10 @@ public class Controller {
     @GetMapping("/status")
     public ResponseEntity<String> pingServidor() {
         String apelido       = "API_Chat_TCP";
-        int portaPrivada     = 1998;
+        int portaPrivada     = PORTA_SERVIDOR;
         String handshake     = apelido + ";" + portaPrivada;
 
-        try (Socket socket = new Socket("127.0.0.1", 1998);
+        try (Socket socket = new Socket(HOST, PORTA_SERVIDOR);
              OutputStream out = socket.getOutputStream();
              InputStream in  = socket.getInputStream()) {
 
@@ -155,10 +155,10 @@ public class Controller {
     @GetMapping("/desconectar")
     public ResponseEntity<String> desconectarUsuario(@RequestParam String apelido) {
         String apelidoApi   = "API_Chat_TCP";
-        int portaPrivada    = 1998;
+        int portaPrivada    = PORTA_SERVIDOR;
         String handshake    = apelidoApi + ";" + portaPrivada;
 
-        try (Socket socket = new Socket("127.0.0.1", 1998);
+        try (Socket socket = new Socket(HOST, PORTA_SERVIDOR);
              OutputStream out = socket.getOutputStream();
              InputStream in  = socket.getInputStream()) {
 

--- a/Trabalho_Chat_TCP/ServidorChat/Program.cs
+++ b/Trabalho_Chat_TCP/ServidorChat/Program.cs
@@ -9,17 +9,36 @@ namespace Chat_TCP
 {
     class Program
     {
-        static TcpListener listener;
+        static TcpListener listenerChat;
+        static TcpListener listenerApi;
         static List<(TcpClient cliente, string apelido, string ip, int portaPrivada)> clientes = new();
         static object locker = new();
 
         static void Main()
         {
-            int porta = 1998;
-            listener = new TcpListener(IPAddress.Any, porta);
-            listener.Start();
-            Console.WriteLine($"Servidor ouvindo em todas as interfaces na porta {porta}");
+            const int portaChat = 1998;
+            const int portaApi  = 2998;
 
+            listenerChat = new TcpListener(IPAddress.Any, portaChat);
+            listenerApi  = new TcpListener(IPAddress.Any, portaApi);
+
+            listenerChat.Start();
+            listenerApi.Start();
+
+            Console.WriteLine($"Servidor ouvindo na porta {portaChat} (chat) e {portaApi} (api)");
+
+            Thread tChat = new(() => AceitarConexoes(listenerChat));
+            Thread tApi  = new(() => AceitarConexoes(listenerApi));
+
+            tChat.Start();
+            tApi.Start();
+
+            tChat.Join();
+            tApi.Join();
+        }
+
+        static void AceitarConexoes(TcpListener listener)
+        {
             while (true)
             {
                 TcpClient cliente = listener.AcceptTcpClient();


### PR DESCRIPTION
## Summary
- support two separate listeners in the chat server
- connect API requests using new port 2998 instead of the chat port

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d5ab33d588323aa5119d0fbc30afd